### PR TITLE
Add SVN to test.yaml workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,9 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
 
     steps:
+      - name: Install subversion
+        run: sudo apt-get install -y subversion
+
       - name: 'Checkout'
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Ubuntu-latest got updated to 24.04, which no longer contains SVN. This additional step in the CI pipeline installs it again.

Based on Yoast/wordpress-seo#21706.